### PR TITLE
修正 TechStack.md，移除未實際安裝於 frontend/package.json 的套件

### DIFF
--- a/TechStack.md
+++ b/TechStack.md
@@ -8,10 +8,8 @@
 - **Vite**（建置工具，熱更新極速）
 - **React 19**（主流 UI 框架）
 - **React Router v7**（前端路由）
-- **Tailwind CSS v3**（Utility-first CSS）
 - **MUI（Material UI）**（UI 元件庫）
 - **Zustand**（Client State 管理）
-- **TanStack Query**（Server State 管理）
 - **Axios**（HTTP 請求）
 
 ## 後端框架


### PR DESCRIPTION
## 說明

對應 issue #42。

移除 `TechStack.md` 中未實際安裝於 `frontend/package.json` 的套件：

- 移除 `**Tailwind CSS v3**（Utility-first CSS）`
- 移除 `**TanStack Query**（Server State 管理）`

Axios 保留（已決定導入）。

## 變更範圍

- `TechStack.md`：刪除 2 行

Closes #42