### PR TITLE
[Chore] Prototype 細部調整

### DIFF
--- a/Prototype/fn_ai_partner_setting.html
+++ b/Prototype/fn_ai_partner_setting.html
@@ -23,7 +23,6 @@
                         <tr>
                             <th>夥伴名稱</th>
                             <th>描述</th>
-                            <th>啟用狀態</th>
                             <th>執行動作</th>
                         </tr>
                     </thead>
@@ -53,13 +52,9 @@
         allPartners
             .filter(p => !keyword || p.name.toLowerCase().includes(keyword) || (p.desc || '').toLowerCase().includes(keyword))
             .forEach(p => {
-                const enabledHtml = p.enabled
-                    ? '<span style="display:inline-flex;align-items:center;gap:5px;color:#10b981;font-weight:600;"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M9 12l2 2 4-4"/></svg> 啟用</span>'
-                    : '<span style="display:inline-flex;align-items:center;gap:5px;color:#94a3b8;font-weight:600;"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="9" y1="9" x2="15" y2="15"/><line x1="15" y1="9" x2="9" y2="15"/></svg> 停用</span>';
                 tbody.innerHTML += '<tr>' +
                     '<td style="font-weight:600;">' + p.name + '</td>' +
                     '<td style="color:#475569;">' + (p.desc || '') + '</td>' +
-                    '<td>' + enabledHtml + '</td>' +
                     '<td>' +
                         '<button class="btn btn-outline" style="padding:4px 10px;" onclick="location.href=\'' + partnerSettingHref(p) + '\'">設定</button>' +
                     '</td>' +

--- a/Prototype/fn_company_data.html
+++ b/Prototype/fn_company_data.html
@@ -24,8 +24,9 @@
             <div class="card filter-bar">
                 <div class="filter-group">
                     <label>關鍵字:</label>
-                    <input type="text" id="filterKeyword" oninput="renderCompanyDataTable()" placeholder="搜尋資料名稱或內容...">
+                    <input type="text" id="filterKeyword" placeholder="搜尋資料名稱、內容、適用夥伴...">
                 </div>
+                <button class="btn-filter" onclick="renderCompanyDataTable()">套用</button>
                 <button class="btn btn-primary" style="margin-left:auto" onclick="openCompanyDataModal()">新增資料</button>
             </div>
             <div class="card" style="padding:0;">
@@ -87,9 +88,10 @@
     function renderCompanyDataTable() {
         var kw = (document.getElementById('filterKeyword').value || '').toLowerCase().trim();
         var rows = allCompanyData.filter(function(d){
-            return !kw
-                || (d.name || '').toLowerCase().indexOf(kw) !== -1
-                || (d.content || '').toLowerCase().indexOf(kw) !== -1;
+            if (!kw) return true;
+            var partners = Array.isArray(d.partners) ? d.partners.join('、') : '';
+            var haystack = [(d.name || ''), (d.content || ''), partners].join('\n').toLowerCase();
+            return haystack.indexOf(kw) !== -1;
         });
         var tbody = document.getElementById('companyDataTableBody');
         if (rows.length === 0) {
@@ -127,8 +129,7 @@
             var checked = bound.indexOf(p.name) !== -1 ? 'checked' : '';
             return '<label style="display:flex;align-items:center;gap:8px;padding:8px 10px;border:1px solid #e2e8f0;border-radius:6px;cursor:pointer;font-weight:400;">' +
                 '<input type="checkbox" data-partner="' + escapeHtml(p.name) + '" ' + checked + '>' +
-                '<span><strong style="color:#1e293b;">' + escapeHtml(p.name) + '</strong>' +
-                '<small style="display:block;color:#64748b;font-size:11px;">' + escapeHtml(p.desc || '') + '</small></span>' +
+                '<span><strong style="color:#1e293b;">' + escapeHtml(p.name) + '</strong></span>' +
                 '</label>';
         }).join('');
     }

--- a/Prototype/fn_expert_setting.html
+++ b/Prototype/fn_expert_setting.html
@@ -11,8 +11,6 @@
         <!-- sidebar + header 由 _nav.js 注入 -->
         <div class="main-content">
 
-            <p style="font-size:12px; color:#94a3b8; margin-bottom:8px;">內建夥伴 · 不可刪除</p>
-
             <!-- 排程 -->
             <div class="card" style="margin-bottom:18px;">
                 <h3 style="font-size:15px; color:#1e293b; margin-bottom:14px; padding-bottom:10px; border-bottom:1px solid #e2e8f0;">排程</h3>
@@ -56,9 +54,6 @@
             <!-- 資料來源（SSB） -->
             <div class="card" style="margin-bottom:18px;">
                 <h3 style="font-size:15px; color:#1e293b; margin-bottom:14px; padding-bottom:10px; border-bottom:1px solid #e2e8f0;">資料來源（syslog-ng Store Box）</h3>
-                <p style="font-size:12px; color:#64748b; margin-bottom:14px;">
-                    通訊協定：HTTPS　·　API 版本：<code style="font-size:12px;">/api/5/</code>
-                </p>
                 <div style="display:grid; grid-template-columns:1fr 1fr; gap:16px;">
                     <div class="input-group" style="margin-bottom:0;">
                         <label>Host</label>


### PR DESCRIPTION
Closes #129

## 變更摘要

雛型細部調整，跟 sa-92 結果配套。

### `fn_company_data.html`
- 適用夥伴 modal 移除夥伴下方 desc 文字（不再顯示「排程、資料來源」這些字）
- 關鍵字搜尋加「套用」按鈕（改為 click 觸發，不再 oninput 即時）
- 搜尋範圍擴大為全域：資料名稱 + 內容 + 適用夥伴

### `fn_ai_partner_setting.html`
- 移除「啟用狀態」欄位

### `fn_expert_setting.html`
- 移除「內建夥伴 · 不可刪除」文字
- 移除 SSB 區「通訊協定：HTTPS · API 版本：/api/5/」資訊文字